### PR TITLE
Loosen topology

### DIFF
--- a/functionalTests/src/test/java/ch/so/agi/ipwvalidator/Leitung.java
+++ b/functionalTests/src/test/java/ch/so/agi/ipwvalidator/Leitung.java
@@ -233,6 +233,7 @@ public class Leitung {
         assertFalse(content.contains("Error"));
     }
     
+    @Disabled
     @Test
     public void Id_12013_fail(@TempDir Path tempDir) throws Exception {
         String logFileName = Paths.get(tempDir.toFile().getAbsolutePath(), LOGFILE_NAME).toFile().getAbsolutePath();
@@ -250,7 +251,7 @@ public class Leitung {
         assertTrue(content.contains("Error: line 41: VSADSSMINI_2020_LV95.VSADSSMini.Leitung: tid deg5mQXX20002002: MANDATORY Knoten_nachRef (gilt für PAA)"));
     }
     
-    //@Disabled
+    @Disabled
     @Test
     public void Id_12013_ok(@TempDir Path tempDir) throws Exception {
         String logFileName = Paths.get(tempDir.toFile().getAbsolutePath(), LOGFILE_NAME).toFile().getAbsolutePath();
@@ -269,6 +270,7 @@ public class Leitung {
         assertFalse(content.contains("Error"));
     }
 
+    @Disabled
     @Test
     public void Id_12014_fail(@TempDir Path tempDir) throws Exception {
         String logFileName = Paths.get(tempDir.toFile().getAbsolutePath(), LOGFILE_NAME).toFile().getAbsolutePath();
@@ -286,7 +288,7 @@ public class Leitung {
         assertTrue(content.contains("Error: line 41: VSADSSMINI_2020_LV95.VSADSSMini.Leitung: tid deg5mQXX20002002: MANDATORY Knoten_vonRef (gilt für PAA)"));
     }
     
-    //@Disabled
+    @Disabled
     @Test
     public void Id_12014_ok(@TempDir Path tempDir) throws Exception {
         String logFileName = Paths.get(tempDir.toFile().getAbsolutePath(), LOGFILE_NAME).toFile().getAbsolutePath();

--- a/model/2022-06-24/VSADSSMINI_2020_LV95_Validierung_IPW_20220624.ili
+++ b/model/2022-06-24/VSADSSMINI_2020_LV95_Validierung_IPW_20220624.ili
@@ -1,0 +1,215 @@
+INTERLIS 2.3;
+
+CONTRACTED MODEL VSADSSMINI_2020_LV95_Validierung_IPW_20220624 (de)
+AT "https://geo.so.ch"
+VERSION "2022-06-24"  =
+  
+IMPORTS SIA405_Base_Abwasser_LV95;
+IMPORTS VSADSSMINI_2020_LV95;
+IMPORTS UNQUALIFIED INTERLIS;
+  
+  VIEW TOPIC VSADSSMini_Validierung = 
+  DEPENDS ON VSADSSMINI_2020_LV95.VSADSSMini, SIA405_Base_Abwasser_LV95.Administration;
+  
+    VIEW v_Knoten
+      PROJECTION OF VSADSSMINI_2020_LV95.VSADSSMini.Knoten;
+    =
+      ALL OF Knoten;
+                
+      !!@ name = 11001
+      !!@ ilivalid.msg = "MANDATORY ARA_Nr"
+      MANDATORY CONSTRAINT DEFINED (ARA_Nr);
+
+      !!@ name = 11012
+      !!@ ilivalid.msg = "MANDATORY Finanzierung AND != unbekannt"
+      MANDATORY CONSTRAINT DEFINED(Finanzierung) AND Finanzierung != #unbekannt;
+
+      !!@ name = 11013
+      !!@ ilivalid.msg = "MANDATORY Funktion AND != unbekannt"
+      MANDATORY CONSTRAINT DEFINED(Funktion) AND Funktion != #unbekannt;
+
+      !!@ name = 11014
+      !!@ ilivalid.msg = "MANDATORY FunktionHierarchisch"
+      MANDATORY CONSTRAINT DEFINED(FunktionHierarchisch);
+
+      !!@ name = 11015
+      !!@ ilivalid.msg = "MANDATORY Lage"
+      MANDATORY CONSTRAINT DEFINED(Lage);
+
+      !!@ name = 11018
+      !!@ ilivalid.msg = "MANDATORY Nutzungsart_Ist AND != unbekannt"
+      MANDATORY CONSTRAINT DEFINED(Nutzungsart_Ist) AND Nutzungsart_Ist != #unbekannt;
+
+      !!@ name = 11025
+      !!@ ilivalid.msg = "MANDATORY Status AND != unbekannt"
+      MANDATORY CONSTRAINT DEFINED(Status) AND Status != #unbekannt;
+
+    END v_Knoten;
+
+    VIEW v_Leitung
+      PROJECTION OF VSADSSMINI_2020_LV95.VSADSSMini.Leitung;
+      =
+      ALL OF Leitung;
+
+      !!@ name = 12007
+      !!@ ilivalid.msg = "MANDATORY Finanzierung AND != unbekannt"
+      MANDATORY CONSTRAINT DEFINED(Finanzierung) AND Finanzierung != #unbekannt;
+
+      !!@ name = 12008
+      !!@ ilivalid.msg = "MANDATORY FunktionHierarchisch AND != unbekannt"
+      MANDATORY CONSTRAINT DEFINED(FunktionHierarchisch) AND FunktionHierarchisch != #PAA.unbekannt AND FunktionHierarchisch != #SAA.unbekannt;
+
+      !!@ name = 12009
+      !!@ ilivalid.msg = "MANDATORY FunktionHydraulisch AND != unbekannt"
+      MANDATORY CONSTRAINT DEFINED(FunktionHydraulisch) AND FunktionHydraulisch != #unbekannt;
+
+      !!@ name = 12021
+      !!@ ilivalid.msg = "MANDATORY Lichte_Breite (gilt für PAA)"
+      MANDATORY CONSTRAINT DEFINED(Lichte_Breite) OR isEnumSubVal(FunktionHierarchisch,#SAA);
+
+      !!@ name = 12022
+      !!@ ilivalid.msg = "MANDATORY Lichte_Hoehe (gilt für PAA)"
+      MANDATORY CONSTRAINT DEFINED(Lichte_Hoehe) OR isEnumSubVal(FunktionHierarchisch,#SAA);
+
+      !!@ name = 12025
+      !!@ ilivalid.msg = "MANDATORY Nutzungsart_Ist AND != unbekannt"
+      MANDATORY CONSTRAINT DEFINED(Nutzungsart_Ist) AND Nutzungsart_Ist != #unbekannt;
+
+      !!@ name = 12030
+      !!@ ilivalid.msg = "MANDATORY Profiltyp (gilt für PAA)"
+      MANDATORY CONSTRAINT DEFINED(Profiltyp) OR isEnumSubVal(FunktionHierarchisch,#SAA);
+
+      !!@ name = 12035
+      !!@ ilivalid.msg = "MANDATORY Status AND != unbekannt"
+      MANDATORY CONSTRAINT DEFINED(Status) AND Status != #unbekannt;
+
+      !!@ name = 12036
+      !!@ ilivalid.msg = "MANDATORY Verlauf"
+      MANDATORY CONSTRAINT DEFINED(Verlauf);
+
+    END v_Leitung;
+
+    VIEW v_Organisation
+      PROJECTION OF SIA405_Base_Abwasser_LV95.Administration.Organisation;
+      =
+      ALL OF Organisation;
+
+      !!@ name = 14901
+      !!@ ilivalid.msg = "Keine Organisation erlaubt"
+      SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
+
+    END v_Organisation;
+
+    VIEW v_Bauwerkskomponente
+      PROJECTION OF VSADSSMINI_2020_LV95.VSADSSMini.Bauwerkskomponente;
+      =
+      ALL OF Bauwerkskomponente;
+
+      !!@ name = 19901
+      !!@ ilivalid.msg = "Keine Bauwerkskomponente erlaubt"
+      SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
+
+    END v_Bauwerkskomponente;
+
+    VIEW v_Kennlinie_Stuetzpunkt
+      PROJECTION OF VSADSSMINI_2020_LV95.VSADSSMini.Kennlinie_Stuetzpunkt;
+      =
+      ALL OF Kennlinie_Stuetzpunkt;
+
+      !!@ name = 19901
+      !!@ ilivalid.msg = "Kein Kennlinie_Stuetzpunkt erlaubt"
+      SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
+
+    END v_Kennlinie_Stuetzpunkt;
+
+    VIEW v_SK_Duekeroberhaupt
+      PROJECTION OF VSADSSMINI_2020_LV95.VSADSSMini.SK_Duekeroberhaupt;
+      =
+      ALL OF SK_Duekeroberhaupt;
+
+      !!@ name = 22901
+      !!@ ilivalid.msg = "Keine SK_Duekeroberhaupt erlaubt"
+      SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
+
+    END v_SK_Duekeroberhaupt;
+
+    VIEW v_SK_Einleitstelle
+      PROJECTION OF VSADSSMINI_2020_LV95.VSADSSMini.SK_Einleitstelle;
+      =
+      ALL OF SK_Einleitstelle;
+
+      !!@ name = 23901
+      !!@ ilivalid.msg = "Keine SK_Einleitstelle erlaubt"
+      SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
+
+    END v_SK_Einleitstelle;
+ 
+    VIEW v_SK_Pumpwerk
+      PROJECTION OF VSADSSMINI_2020_LV95.VSADSSMini.SK_Pumpwerk;
+      =
+      ALL OF SK_Pumpwerk;
+                
+      !!@ name = 24901
+      !!@ ilivalid.msg = "Keine SK_Pumpwerk erlaubt"
+      SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
+
+    END v_SK_Pumpwerk;
+        
+    VIEW v_SK_Regenrueckhaltebecken_kanal
+      PROJECTION OF VSADSSMINI_2020_LV95.VSADSSMini.SK_Regenrueckhaltebecken_kanal;
+      =
+      ALL OF SK_Regenrueckhaltebecken_kanal;
+
+      !!@ name = 25901
+      !!@ ilivalid.msg = "Keine SK_Regenrueckhaltebecken_kanal erlaubt"
+      SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
+
+    END v_SK_Regenrueckhaltebecken_kanal;
+  
+    VIEW v_SK_Regenueberlauf
+      PROJECTION OF VSADSSMINI_2020_LV95.VSADSSMini.SK_Regenueberlauf;
+      =
+      ALL OF SK_Regenueberlauf;
+
+      !!@ name = 26901
+      !!@ ilivalid.msg = "Keine SK_Regenueberlauf erlaubt"
+      SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
+
+    END v_SK_Regenueberlauf;
+        
+    VIEW v_SK_Regenueberlaufbecken
+      PROJECTION OF VSADSSMINI_2020_LV95.VSADSSMini.SK_Regenueberlaufbecken;
+      =
+      ALL OF SK_Regenueberlaufbecken;
+
+      !!@ name = 27901
+      !!@ ilivalid.msg = "Keine SK_Regenueberlaufbecken erlaubt"
+      SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
+
+    END v_SK_Regenueberlaufbecken;
+
+    VIEW v_SK_Trennbauwerk
+      PROJECTION OF VSADSSMINI_2020_LV95.VSADSSMini.SK_Trennbauwerk;
+      =
+      ALL OF SK_Trennbauwerk;
+
+      !!@ name = 28901
+      !!@ ilivalid.msg = "Keine SK_Trennbauwerk erlaubt"
+      SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
+
+    END v_SK_Trennbauwerk;
+
+    VIEW v_SK_Uebrige
+      PROJECTION OF VSADSSMINI_2020_LV95.VSADSSMini.SK_Uebrige;
+      =
+      ALL OF SK_Uebrige;
+
+      !!@ name = 29901
+      !!@ ilivalid.msg = "Keine SK_Uebrige erlaubt"
+      SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
+      
+    END v_SK_Uebrige;
+
+  END VSADSSMini_Validierung;
+
+END VSADSSMINI_2020_LV95_Validierung_IPW_20220624.

--- a/model/2022-06-24/config.toml
+++ b/model/2022-06-24/config.toml
@@ -1,0 +1,3 @@
+["PARAMETER"]
+additionalModels="VSADSSMINI_2020_LV95_Validierung_IPW_20220624"
+


### PR DESCRIPTION
I suggest to remove constraints 12013 and 12014 (which ensures topology). I introduced this topic in my email from April 7, 2022 but I now realise that this would probably prevent a lot of datasets to pass stage 1.