### PR TITLE
Update validation model

### DIFF
--- a/model/2023-02-07/VSADSSMINI_2020_LV95_Validierung_IPW_20230207.ili
+++ b/model/2023-02-07/VSADSSMINI_2020_LV95_Validierung_IPW_20230207.ili
@@ -1,0 +1,215 @@
+INTERLIS 2.3;
+
+CONTRACTED MODEL VSADSSMINI_2020_LV95_Validierung_IPW_20230207 (de)
+AT "https://geo.so.ch"
+VERSION "2023-02-07"  =
+  
+IMPORTS SIA405_Base_Abwasser_LV95;
+IMPORTS VSADSSMINI_2020_LV95;
+IMPORTS UNQUALIFIED INTERLIS;
+  
+  VIEW TOPIC VSADSSMini_Validierung = 
+  DEPENDS ON VSADSSMINI_2020_LV95.VSADSSMini, SIA405_Base_Abwasser_LV95.Administration;
+  
+    VIEW v_Knoten
+      PROJECTION OF VSADSSMINI_2020_LV95.VSADSSMini.Knoten;
+    =
+      ALL OF Knoten;
+
+      !!@ name = 11012
+      !!@ ilivalid.msg = "MANDATORY Finanzierung"
+      MANDATORY CONSTRAINT DEFINED(Finanzierung);
+
+      !!@ name = 11013
+      !!@ ilivalid.msg = "MANDATORY Funktion"
+      MANDATORY CONSTRAINT DEFINED(Funktion);
+
+      !!@ name = 11014
+      !!@ ilivalid.msg = "MANDATORY FunktionHierarchisch"
+      MANDATORY CONSTRAINT DEFINED(FunktionHierarchisch);
+
+      !!@ name = 11015
+      !!@ ilivalid.msg = "MANDATORY Lage"
+      MANDATORY CONSTRAINT DEFINED(Lage);
+
+      !!@ name = 11025
+      !!@ ilivalid.msg = "MANDATORY Status"
+      MANDATORY CONSTRAINT DEFINED(Status);
+
+      !!@ name = 11101
+      !!@ ilivalid.msg = "weniger als 80% Finanzierung erfasst"
+      CONSTRAINT >= 80% DEFINED(Finanzierung);
+
+      !!@ name = 11102
+      !!@ ilivalid.msg = "weniger als 90% Status erfasst"
+      CONSTRAINT >= 90% DEFINED(Status);
+
+    END v_Knoten;
+
+    VIEW v_Leitung
+      PROJECTION OF VSADSSMINI_2020_LV95.VSADSSMini.Leitung;
+      =
+      ALL OF Leitung;
+
+      !!@ name = 12007
+      !!@ ilivalid.msg = "MANDATORY Finanzierung"
+      MANDATORY CONSTRAINT DEFINED(Finanzierung);
+
+      !!@ name = 12008
+      !!@ ilivalid.msg = "MANDATORY FunktionHierarchisch"
+      MANDATORY CONSTRAINT DEFINED(FunktionHierarchisch);
+
+      !!@ name = 12009
+      !!@ ilivalid.msg = "MANDATORY FunktionHydraulisch"
+      MANDATORY CONSTRAINT DEFINED(FunktionHydraulisch);
+
+      !!@ name = 12025
+      !!@ ilivalid.msg = "MANDATORY Nutzungsart_Ist AND != unbekannt"
+      MANDATORY CONSTRAINT DEFINED(Nutzungsart_Ist) AND Nutzungsart_Ist != #unbekannt;
+
+      !!@ name = 12035
+      !!@ ilivalid.msg = "MANDATORY Status"
+      MANDATORY CONSTRAINT DEFINED(Status);
+
+      !!@ name = 12036
+      !!@ ilivalid.msg = "MANDATORY Verlauf"
+      MANDATORY CONSTRAINT DEFINED(Verlauf);
+
+      !!@ name = 12101
+      !!@ ilivalid.msg = "weniger als 80% Finanzierung erfasst"
+      CONSTRAINT >= 80% DEFINED(Finanzierung);
+
+      !!@ name = 12102
+      !!@ ilivalid.msg = "weniger als 90% Nutzungsart erfasst"
+      CONSTRAINT >= 90% DEFINED(Nutzungsart_Ist);
+
+      !!@ name = 12103
+      !!@ ilivalid.msg = "weniger als 90% Status erfasst"
+      CONSTRAINT >= 90% DEFINED(Status);
+
+    END v_Leitung;
+
+    VIEW v_Organisation
+      PROJECTION OF SIA405_Base_Abwasser_LV95.Administration.Organisation;
+      =
+      ALL OF Organisation;
+
+      !!@ name = 14901
+      !!@ ilivalid.msg = "Keine Organisation erlaubt"
+      SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
+
+    END v_Organisation;
+
+    VIEW v_Bauwerkskomponente
+      PROJECTION OF VSADSSMINI_2020_LV95.VSADSSMini.Bauwerkskomponente;
+      =
+      ALL OF Bauwerkskomponente;
+
+      !!@ name = 19901
+      !!@ ilivalid.msg = "Keine Bauwerkskomponente erlaubt"
+      SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
+
+    END v_Bauwerkskomponente;
+
+    VIEW v_Kennlinie_Stuetzpunkt
+      PROJECTION OF VSADSSMINI_2020_LV95.VSADSSMini.Kennlinie_Stuetzpunkt;
+      =
+      ALL OF Kennlinie_Stuetzpunkt;
+
+      !!@ name = 19901
+      !!@ ilivalid.msg = "Kein Kennlinie_Stuetzpunkt erlaubt"
+      SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
+
+    END v_Kennlinie_Stuetzpunkt;
+
+    VIEW v_SK_Duekeroberhaupt
+      PROJECTION OF VSADSSMINI_2020_LV95.VSADSSMini.SK_Duekeroberhaupt;
+      =
+      ALL OF SK_Duekeroberhaupt;
+
+      !!@ name = 22901
+      !!@ ilivalid.msg = "Keine SK_Duekeroberhaupt erlaubt"
+      SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
+
+    END v_SK_Duekeroberhaupt;
+
+    VIEW v_SK_Einleitstelle
+      PROJECTION OF VSADSSMINI_2020_LV95.VSADSSMini.SK_Einleitstelle;
+      =
+      ALL OF SK_Einleitstelle;
+
+      !!@ name = 23901
+      !!@ ilivalid.msg = "Keine SK_Einleitstelle erlaubt"
+      SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
+
+    END v_SK_Einleitstelle;
+ 
+    VIEW v_SK_Pumpwerk
+      PROJECTION OF VSADSSMINI_2020_LV95.VSADSSMini.SK_Pumpwerk;
+      =
+      ALL OF SK_Pumpwerk;
+                
+      !!@ name = 24901
+      !!@ ilivalid.msg = "Keine SK_Pumpwerk erlaubt"
+      SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
+
+    END v_SK_Pumpwerk;
+        
+    VIEW v_SK_Regenrueckhaltebecken_kanal
+      PROJECTION OF VSADSSMINI_2020_LV95.VSADSSMini.SK_Regenrueckhaltebecken_kanal;
+      =
+      ALL OF SK_Regenrueckhaltebecken_kanal;
+
+      !!@ name = 25901
+      !!@ ilivalid.msg = "Keine SK_Regenrueckhaltebecken_kanal erlaubt"
+      SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
+
+    END v_SK_Regenrueckhaltebecken_kanal;
+  
+    VIEW v_SK_Regenueberlauf
+      PROJECTION OF VSADSSMINI_2020_LV95.VSADSSMini.SK_Regenueberlauf;
+      =
+      ALL OF SK_Regenueberlauf;
+
+      !!@ name = 26901
+      !!@ ilivalid.msg = "Keine SK_Regenueberlauf erlaubt"
+      SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
+
+    END v_SK_Regenueberlauf;
+        
+    VIEW v_SK_Regenueberlaufbecken
+      PROJECTION OF VSADSSMINI_2020_LV95.VSADSSMini.SK_Regenueberlaufbecken;
+      =
+      ALL OF SK_Regenueberlaufbecken;
+
+      !!@ name = 27901
+      !!@ ilivalid.msg = "Keine SK_Regenueberlaufbecken erlaubt"
+      SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
+
+    END v_SK_Regenueberlaufbecken;
+
+    VIEW v_SK_Trennbauwerk
+      PROJECTION OF VSADSSMINI_2020_LV95.VSADSSMini.SK_Trennbauwerk;
+      =
+      ALL OF SK_Trennbauwerk;
+
+      !!@ name = 28901
+      !!@ ilivalid.msg = "Keine SK_Trennbauwerk erlaubt"
+      SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
+
+    END v_SK_Trennbauwerk;
+
+    VIEW v_SK_Uebrige
+      PROJECTION OF VSADSSMINI_2020_LV95.VSADSSMini.SK_Uebrige;
+      =
+      ALL OF SK_Uebrige;
+
+      !!@ name = 29901
+      !!@ ilivalid.msg = "Keine SK_Uebrige erlaubt"
+      SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
+      
+    END v_SK_Uebrige;
+
+  END VSADSSMini_Validierung;
+
+END VSADSSMINI_2020_LV95_Validierung_IPW_20230207.

--- a/model/2023-02-07/VSADSSMINI_2020_LV95_Validierung_IPW_20230207.ili
+++ b/model/2023-02-07/VSADSSMINI_2020_LV95_Validierung_IPW_20230207.ili
@@ -116,8 +116,8 @@ IMPORTS UNQUALIFIED INTERLIS;
       =
       ALL OF Kennlinie_Stuetzpunkt;
 
-      !!@ name = 19901
       !!@ ilivalid.msg = "Kein Kennlinie_Stuetzpunkt erlaubt"
+      !!@ name = 20901
       SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
 
     END v_Kennlinie_Stuetzpunkt;

--- a/model/2023-02-07/VSADSSMINI_2020_LV95_Validierung_IPW_20230207.ili
+++ b/model/2023-02-07/VSADSSMINI_2020_LV95_Validierung_IPW_20230207.ili
@@ -17,31 +17,31 @@ IMPORTS UNQUALIFIED INTERLIS;
       ALL OF Knoten;
 
       !!@ name = 11012
-      !!@ ilivalid.msg = "MANDATORY Finanzierung"
+      !!@ ilivalid.msg = "Knoten: MANDATORY Finanzierung"
       MANDATORY CONSTRAINT DEFINED(Finanzierung);
 
       !!@ name = 11013
-      !!@ ilivalid.msg = "MANDATORY Funktion"
+      !!@ ilivalid.msg = "Knoten: MANDATORY Funktion"
       MANDATORY CONSTRAINT DEFINED(Funktion);
 
       !!@ name = 11014
-      !!@ ilivalid.msg = "MANDATORY FunktionHierarchisch"
+      !!@ ilivalid.msg = "Knoten: MANDATORY FunktionHierarchisch"
       MANDATORY CONSTRAINT DEFINED(FunktionHierarchisch);
 
       !!@ name = 11015
-      !!@ ilivalid.msg = "MANDATORY Lage"
+      !!@ ilivalid.msg = "Knoten: MANDATORY Lage"
       MANDATORY CONSTRAINT DEFINED(Lage);
 
       !!@ name = 11025
-      !!@ ilivalid.msg = "MANDATORY Status"
+      !!@ ilivalid.msg = "Knoten: MANDATORY Status"
       MANDATORY CONSTRAINT DEFINED(Status);
 
       !!@ name = 11101
-      !!@ ilivalid.msg = "weniger als 80% Finanzierung erfasst"
+      !!@ ilivalid.msg = "Knoten: weniger als 80% Finanzierung erfasst"
       CONSTRAINT >= 80% DEFINED(Finanzierung);
 
       !!@ name = 11102
-      !!@ ilivalid.msg = "weniger als 90% Status erfasst"
+      !!@ ilivalid.msg = "Knoten: weniger als 90% Status erfasst"
       CONSTRAINT >= 90% DEFINED(Status);
 
     END v_Knoten;
@@ -52,39 +52,39 @@ IMPORTS UNQUALIFIED INTERLIS;
       ALL OF Leitung;
 
       !!@ name = 12007
-      !!@ ilivalid.msg = "MANDATORY Finanzierung"
+      !!@ ilivalid.msg = "Leitung: MANDATORY Finanzierung"
       MANDATORY CONSTRAINT DEFINED(Finanzierung);
 
       !!@ name = 12008
-      !!@ ilivalid.msg = "MANDATORY FunktionHierarchisch"
+      !!@ ilivalid.msg = "Leitung: MANDATORY FunktionHierarchisch"
       MANDATORY CONSTRAINT DEFINED(FunktionHierarchisch);
 
       !!@ name = 12009
-      !!@ ilivalid.msg = "MANDATORY FunktionHydraulisch"
+      !!@ ilivalid.msg = "Leitung: MANDATORY FunktionHydraulisch"
       MANDATORY CONSTRAINT DEFINED(FunktionHydraulisch);
 
       !!@ name = 12025
-      !!@ ilivalid.msg = "MANDATORY Nutzungsart_Ist AND != unbekannt"
+      !!@ ilivalid.msg = "Leitung: MANDATORY Nutzungsart_Ist AND != unbekannt"
       MANDATORY CONSTRAINT DEFINED(Nutzungsart_Ist) AND Nutzungsart_Ist != #unbekannt;
 
       !!@ name = 12035
-      !!@ ilivalid.msg = "MANDATORY Status"
+      !!@ ilivalid.msg = "Leitung: MANDATORY Status"
       MANDATORY CONSTRAINT DEFINED(Status);
 
       !!@ name = 12036
-      !!@ ilivalid.msg = "MANDATORY Verlauf"
+      !!@ ilivalid.msg = "Leitung: MANDATORY Verlauf"
       MANDATORY CONSTRAINT DEFINED(Verlauf);
 
       !!@ name = 12101
-      !!@ ilivalid.msg = "weniger als 80% Finanzierung erfasst"
+      !!@ ilivalid.msg = "Leitung: weniger als 80% Finanzierung erfasst"
       CONSTRAINT >= 80% DEFINED(Finanzierung);
 
       !!@ name = 12102
-      !!@ ilivalid.msg = "weniger als 90% Nutzungsart erfasst"
+      !!@ ilivalid.msg = "Leitung: weniger als 90% Nutzungsart erfasst"
       CONSTRAINT >= 90% DEFINED(Nutzungsart_Ist);
 
       !!@ name = 12103
-      !!@ ilivalid.msg = "weniger als 90% Status erfasst"
+      !!@ ilivalid.msg = "Leitung: weniger als 90% Status erfasst"
       CONSTRAINT >= 90% DEFINED(Status);
 
     END v_Leitung;

--- a/model/2023-02-07/VSADSSMINI_2020_LV95_Validierung_IPW_20230207.ili
+++ b/model/2023-02-07/VSADSSMINI_2020_LV95_Validierung_IPW_20230207.ili
@@ -95,7 +95,7 @@ IMPORTS UNQUALIFIED INTERLIS;
       ALL OF Organisation;
 
       !!@ name = 14901
-      !!@ ilivalid.msg = "Keine Organisation erlaubt"
+      !!@ ilivalid.msg = "Zusätzliche Organisationen werden ignoriert"
       SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
 
     END v_Organisation;
@@ -106,7 +106,7 @@ IMPORTS UNQUALIFIED INTERLIS;
       ALL OF Bauwerkskomponente;
 
       !!@ name = 19901
-      !!@ ilivalid.msg = "Keine Bauwerkskomponente erlaubt"
+      !!@ ilivalid.msg = "Bauwerkskomponente wird ignoriert"
       SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
 
     END v_Bauwerkskomponente;
@@ -116,8 +116,8 @@ IMPORTS UNQUALIFIED INTERLIS;
       =
       ALL OF Kennlinie_Stuetzpunkt;
 
-      !!@ ilivalid.msg = "Kein Kennlinie_Stuetzpunkt erlaubt"
       !!@ name = 20901
+      !!@ ilivalid.msg = "Kennlinie_Stuetzpunkt wird ignoriert"
       SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
 
     END v_Kennlinie_Stuetzpunkt;
@@ -128,7 +128,7 @@ IMPORTS UNQUALIFIED INTERLIS;
       ALL OF SK_Duekeroberhaupt;
 
       !!@ name = 22901
-      !!@ ilivalid.msg = "Keine SK_Duekeroberhaupt erlaubt"
+      !!@ ilivalid.msg = "SK_Duekeroberhaupt: Stammkarten werden ignoriert"
       SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
 
     END v_SK_Duekeroberhaupt;
@@ -139,7 +139,7 @@ IMPORTS UNQUALIFIED INTERLIS;
       ALL OF SK_Einleitstelle;
 
       !!@ name = 23901
-      !!@ ilivalid.msg = "Keine SK_Einleitstelle erlaubt"
+      !!@ ilivalid.msg = "SK_Einleitstelle: Stammkarten werden ignoriert"
       SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
 
     END v_SK_Einleitstelle;
@@ -150,7 +150,7 @@ IMPORTS UNQUALIFIED INTERLIS;
       ALL OF SK_Pumpwerk;
                 
       !!@ name = 24901
-      !!@ ilivalid.msg = "Keine SK_Pumpwerk erlaubt"
+      !!@ ilivalid.msg = "SK_Pumpwerk: Stammkarten werden ignoriert"
       SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
 
     END v_SK_Pumpwerk;
@@ -161,7 +161,7 @@ IMPORTS UNQUALIFIED INTERLIS;
       ALL OF SK_Regenrueckhaltebecken_kanal;
 
       !!@ name = 25901
-      !!@ ilivalid.msg = "Keine SK_Regenrueckhaltebecken_kanal erlaubt"
+      !!@ ilivalid.msg = "SK_Regenrueckhaltebecken_kanal: Stammkarten werden ignoriert"
       SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
 
     END v_SK_Regenrueckhaltebecken_kanal;
@@ -172,7 +172,7 @@ IMPORTS UNQUALIFIED INTERLIS;
       ALL OF SK_Regenueberlauf;
 
       !!@ name = 26901
-      !!@ ilivalid.msg = "Keine SK_Regenueberlauf erlaubt"
+      !!@ ilivalid.msg = "SK_Regenueberlauf: Stammkarten werden ignoriert"
       SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
 
     END v_SK_Regenueberlauf;
@@ -183,7 +183,7 @@ IMPORTS UNQUALIFIED INTERLIS;
       ALL OF SK_Regenueberlaufbecken;
 
       !!@ name = 27901
-      !!@ ilivalid.msg = "Keine SK_Regenueberlaufbecken erlaubt"
+      !!@ ilivalid.msg = "SK_Regenueberlaufbecken: Stammkarten werden ignoriert"
       SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
 
     END v_SK_Regenueberlaufbecken;
@@ -194,7 +194,7 @@ IMPORTS UNQUALIFIED INTERLIS;
       ALL OF SK_Trennbauwerk;
 
       !!@ name = 28901
-      !!@ ilivalid.msg = "Keine SK_Trennbauwerk erlaubt"
+      !!@ ilivalid.msg = "SK_Trennbauwerk: Stammkarten werden ignoriert"
       SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
 
     END v_SK_Trennbauwerk;
@@ -205,7 +205,7 @@ IMPORTS UNQUALIFIED INTERLIS;
       ALL OF SK_Uebrige;
 
       !!@ name = 29901
-      !!@ ilivalid.msg = "Keine SK_Uebrige erlaubt"
+      !!@ ilivalid.msg = "SK_Uebrige: Stammkarten werden ignoriert"
       SET CONSTRAINT INTERLIS.objectCount(ALL)==0; 
       
     END v_SK_Uebrige;

--- a/model/2023-02-07/config.toml
+++ b/model/2023-02-07/config.toml
@@ -121,3 +121,27 @@ multiplicity="off"
 ["VSADSSMINI_2020_LV95.VSADSSMini.Teileinzugsgebiet.Constraint1"]
 check="off"
 
+##
+## Validierung Massnahme deaktivieren
+##
+
+# Bezeichnung
+["VSADSSMINI_2020_LV95.VSADSSMini.Massnahme.Bezeichnung"]
+multiplicity="off"
+
+# Unique Constraint
+["VSADSSMINI_2020_LV95.VSADSSMini.Massnahme.Constraint1"]
+check="off"
+
+##
+## Validierung ALR deaktivieren
+##
+
+# Bezeichnung
+["VSADSSMINI_2020_LV95.VSADSSMini.ALR.Bezeichnung"]
+multiplicity="off"
+
+# Unique Constraint
+["VSADSSMINI_2020_LV95.VSADSSMini.ALR.Constraint1"]
+check="off"
+

--- a/model/2023-02-07/config.toml
+++ b/model/2023-02-07/config.toml
@@ -1,0 +1,75 @@
+["PARAMETER"]
+additionalModels="VSADSSMINI_2020_LV95_Validierung_IPW_20230207"
+
+##
+## Constraint-Warnungen für Knoten
+##
+
+# Finanzierung
+["VSADSSMINI_2020_LV95_Validierung_IPW_20230207.VSADSSMini_Validierung.v_Knoten.11012"]
+check="warning"
+
+# Status
+["VSADSSMINI_2020_LV95_Validierung_IPW_20230207.VSADSSMini_Validierung.v_Knoten.11025"]
+check="warning"
+
+##
+## Constraint-Warnungen für Leitungen
+##
+
+# Finanzierung
+["VSADSSMINI_2020_LV95_Validierung_IPW_20230207.VSADSSMini_Validierung.v_Leitung.12007"]
+check="warning"
+
+# Nutzungsart_Ist
+["VSADSSMINI_2020_LV95_Validierung_IPW_20230207.VSADSSMini_Validierung.v_Leitung.12025"]
+check="warning"
+
+# Status
+["VSADSSMINI_2020_LV95_Validierung_IPW_20230207.VSADSSMini_Validierung.v_Leitung.12035"]
+check="warning"
+
+##
+## Validierung Rohrprofil deaktivieren
+##
+
+# Bezeichnung
+["VSADSSMINI_2020_LV95.VSADSSMini.Rohrprofil.Bezeichnung"]
+multiplicity="off"
+
+# Unique Constraint
+["VSADSSMINI_2020_LV95.VSADSSMini.Rohrprofil.Constraint1"]
+check="off"
+
+##
+## Validierung Ueberlauf_Foerderaggregat deaktivieren
+##
+
+# Bezeichnung
+["VSADSSMINI_2020_LV95.VSADSSMini.Ueberlauf_Foerderaggregat.Bezeichnung"]
+multiplicity="off"
+
+# Unique Constraint
+["VSADSSMINI_2020_LV95.VSADSSMini.Ueberlauf_Foerderaggregat.Constraint1"]
+check="off"
+
+# Rolle 1
+["VSADSSMINI_2020_LV95.VSADSSMini.Ueberlauf_Foerderaggregat_KnotenAssoc.KnotenRef"]
+multiplicity="off"
+
+# Rolle 2
+["VSADSSMINI_2020_LV95.VSADSSMini.Ueberlauf_Foerderaggregat_Knoten_nachAssoc.Knoten_nachRef"]
+multiplicity="off"
+
+##
+## Validierung Teileinzugsgebiet deaktivieren
+##
+
+# Bezeichnung
+["VSADSSMINI_2020_LV95.VSADSSMini.Teileinzugsgebiet.Bezeichnung"]
+multiplicity="off"
+
+# Unique Constraint
+["VSADSSMINI_2020_LV95.VSADSSMini.Teileinzugsgebiet.Constraint1"]
+check="off"
+

--- a/model/2023-02-07/config.toml
+++ b/model/2023-02-07/config.toml
@@ -30,6 +30,54 @@ check="warning"
 check="warning"
 
 ##
+## Warnungen für SET CONSTRAINTS
+##
+
+# Organisation
+["VSADSSMINI_2020_LV95_Validierung_IPW_20230207.VSADSSMini_Validierung.v_Organisation.14901"]
+check="warning"
+
+# Bauwerkskomponente
+["VSADSSMINI_2020_LV95_Validierung_IPW_20230207.VSADSSMini_Validierung.v_Bauwerkskomponente.19901"]
+check="warning"
+
+# Kennlinie_Stuetzpunkt
+["VSADSSMINI_2020_LV95_Validierung_IPW_20230207.VSADSSMini_Validierung.v_Kennlinie_Stuetzpunkt.20901"]
+check="warning"
+
+# SK_Duekeroberhaupt
+["VSADSSMINI_2020_LV95_Validierung_IPW_20230207.VSADSSMini_Validierung.v_SK_Duekeroberhaupt.22901"]
+check="warning"
+
+# SK_Einleitstelle
+["VSADSSMINI_2020_LV95_Validierung_IPW_20230207.VSADSSMini_Validierung.v_SK_Einleitstelle.23901"]
+check="warning"
+
+# SK_Pumpwerk
+["VSADSSMINI_2020_LV95_Validierung_IPW_20230207.VSADSSMini_Validierung.v_SK_Pumpwerk.24901"]
+check="warning"
+
+# SK_Regenrueckhaltebecken_kanal
+["VSADSSMINI_2020_LV95_Validierung_IPW_20230207.VSADSSMini_Validierung.v_SK_Regenrueckhaltebecken_kanal.25901"]
+check="warning"
+
+# SK_Regenueberlauf
+["VSADSSMINI_2020_LV95_Validierung_IPW_20230207.VSADSSMini_Validierung.v_SK_Regenueberlauf.26901"]
+check="warning"
+
+# SK_Regenueberlaufbecken
+["VSADSSMINI_2020_LV95_Validierung_IPW_20230207.VSADSSMini_Validierung.v_SK_Regenueberlaufbecken.27901"]
+check="warning"
+
+# SK_Trennbauwerk
+["VSADSSMINI_2020_LV95_Validierung_IPW_20230207.VSADSSMini_Validierung.v_SK_Trennbauwerk.28901"]
+check="warning"
+
+# SK_Uebrige
+["VSADSSMINI_2020_LV95_Validierung_IPW_20230207.VSADSSMini_Validierung.v_SK_Uebrige.29901"]
+check="warning"
+
+##
 ## Validierung Rohrprofil deaktivieren
 ##
 


### PR DESCRIPTION
Anpassung Validierungsmodell gemäss Sitzung vom 25.01.2023:

#### Knoten
- 11001: ARA_Nr: nicht prüfen
- 11012: Finanzierung: zu 80% erfasst, `unbekannt` erlauben
- 11013: Funktion: `unbekannt`erlauben
- 11018: Nutzungsart_Ist: nicht prüfen
- 11025: Status: zu 90% erfasst, `unbekannt` erlauben

#### Leitung
- 12007: Finanzierung: zu 80% erfasst, `unbekannt` erlauben
- 12008: FunktionHierarchisch: `unbekannt` erlauben
- 12009: FunktionHydraulisch: `unbekannt` erlauben
- 12021: Lichte_Breite: nicht prüfen
- 12022: Lichte_Hoehe: nicht prüfen
- 12025: Nutzungsart_Ist: zu 90% erfasst
- 12030: Profiltyp: nicht prüfen
- 12035: Status: zu 90% erfasst, `unbekannt` erlauben

#### Anpassungen .toml
- Attribute mit fehlenden Werten, für die PlausibilityConstraints gelten, werden nur noch als Warnung ausgeben, nicht als Fehler.
- Validierung für Objekte deaktiviert, die beim Import in IPW (Stufe 1) ignoriert werden (Stammkarten, Massnahmen, Teileinzugsgebiete usw.) 